### PR TITLE
removed incorrect .options from calling of associations

### DIFF
--- a/app/templates/models/_index.js
+++ b/app/templates/models/_index.js
@@ -19,8 +19,8 @@ fs
   })
 
 Object.keys(db).forEach(function(modelName) {
-  if (db[modelName].options.hasOwnProperty('associate')) {
-    db[modelName].options.associate(db)
+  if (db[modelName].hasOwnProperty('associate')) {
+    db[modelName].associate(db)
   }
 })
 


### PR DESCRIPTION
When the models are loading in the generated models/index.js it was trying to call model.options.associate() as the classMethod containing association directives. Corrected it to model.associate();
